### PR TITLE
Fix TypeError in main_window.py

### DIFF
--- a/src/pyucis_viewer/main_window.py
+++ b/src/pyucis_viewer/main_window.py
@@ -88,7 +88,7 @@ class MainWindow(QMainWindow, DataModelListener):
     class ProgressDelegate(QtWidgets.QStyledItemDelegate):
         def paint(self, painter, option, index):
             if index.data(QtCore.Qt.UserRole+1000) is not None:
-                progress = index.data(QtCore.Qt.UserRole+1000)
+                progress = int(index.data(QtCore.Qt.UserRole+1000))
                 opt = QtWidgets.QStyleOptionProgressBar()
                 opt.rect = option.rect
                 opt.minimum = 0


### PR DESCRIPTION
```
Traceback (most recent call last):
  File ".../pyucis_viewer/main_window.py", line 96, in paint
    opt.progress = progress
TypeError: 'float' object cannot be interpreted as an integer
```